### PR TITLE
Supporting Zenoss 5.x

### DIFF
--- a/ZenPacks/PagerDuty/APINotification/actions.py
+++ b/ZenPacks/PagerDuty/APINotification/actions.py
@@ -162,6 +162,8 @@ class PagerDutyEventsAPIAction(IActionBase):
 
     def _processTalExpressions(self, data, environ):
         if type(data) is str or type(data) is unicode:
+            if '${' not in data:
+                return data
             try:
                 return processTalSource(data, **environ)
             except Exception:

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # or saved.  Do not modify them directly here.
 # NB: PACKAGES is deprecated
 NAME = "ZenPacks.PagerDuty.APINotification"
-VERSION = "1.0.0"
+VERSION = "1.1.0"
 AUTHOR = "PagerDuty Inc."
 LICENSE = "BSD New"
 NAMESPACE_PACKAGES = ['ZenPacks', 'ZenPacks.PagerDuty']


### PR DESCRIPTION
This change fixes the issue with Tales expression evaluation when using Zenoss 5.x

The offending error visible in zenactiond.conf is:

2015-11-04 00:28:52,253 ERROR zen.zenactiond: Error executing action: pagerduty on notification hihi
2015-11-04 00:28:52,254 INFO zen.zenactiond: Event:'api.run.pivotal.io|organizations|/Status|4|test pager duty' Trigger:any_event Action:pagerduty Status:FAIL Target:c34b0238-aa5d-44a6-9d00-c9bae019cb87 Info:Unable to perform TALES evaluation on "$

{urls/eventUrl}" – is there an unescaped $?